### PR TITLE
Add missing unit tests

### DIFF
--- a/billing/src/test/java/cl/perfulandia/billing/service/InvoiceServiceTest.java
+++ b/billing/src/test/java/cl/perfulandia/billing/service/InvoiceServiceTest.java
@@ -1,0 +1,13 @@
+package cl.perfulandia.billing.service;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class InvoiceServiceTest {
+    @Test
+    void serviceInstantiates() {
+        InvoiceService service = new InvoiceService();
+        assertNotNull(service);
+    }
+}

--- a/catalog/src/test/java/cl/perfulandia/catalog/service/ProductServiceTest.java
+++ b/catalog/src/test/java/cl/perfulandia/catalog/service/ProductServiceTest.java
@@ -1,0 +1,96 @@
+package cl.perfulandia.catalog.service;
+
+import cl.perfulandia.catalog.dto.ProductRequest;
+import cl.perfulandia.catalog.model.Product;
+import cl.perfulandia.catalog.repository.ProductRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+class ProductServiceTest {
+
+    @Mock
+    private ProductRepository repo;
+    @InjectMocks
+    private ProductService service;
+
+    @BeforeEach
+    void init() {
+        MockitoAnnotations.openMocks(this);
+    }
+
+    @Test
+    void getAllReturnsList() {
+        Product p = new Product();
+        when(repo.findAll()).thenReturn(List.of(p));
+
+        List<Product> result = service.getAll();
+        assertEquals(1, result.size());
+        verify(repo).findAll();
+    }
+
+    @Test
+    void getByIdFound() {
+        Product p = new Product();
+        p.setId(1L);
+        when(repo.findById(1L)).thenReturn(Optional.of(p));
+
+        Product result = service.getById(1L);
+        assertEquals(1L, result.getId());
+    }
+
+    @Test
+    void getByIdNotFoundThrows() {
+        when(repo.findById(2L)).thenReturn(Optional.empty());
+        assertThrows(RuntimeException.class, () -> service.getById(2L));
+    }
+
+    @Test
+    void createSavesProduct() {
+        ProductRequest req = new ProductRequest();
+        req.setName("n");
+        req.setDescription("d");
+        req.setPrice(1.0);
+        req.setCategory("c");
+        Product saved = new Product();
+        saved.setId(3L);
+        when(repo.save(any())).thenReturn(saved);
+
+        Product result = service.create(req);
+        assertEquals(3L, result.getId());
+        verify(repo).save(any(Product.class));
+    }
+
+    @Test
+    void updateModifiesExisting() {
+        Product existing = new Product();
+        existing.setId(4L);
+        existing.setName("old");
+        when(repo.findById(4L)).thenReturn(Optional.of(existing));
+        when(repo.save(existing)).thenReturn(existing);
+
+        ProductRequest req = new ProductRequest();
+        req.setName("new");
+        req.setDescription("d");
+        req.setPrice(2.0);
+        req.setCategory("c");
+
+        Product result = service.update(4L, req);
+        assertEquals("new", result.getName());
+    }
+
+    @Test
+    void deleteDelegates() {
+        service.delete(5L);
+        verify(repo).deleteById(5L);
+    }
+}

--- a/logistics/src/test/java/cl/perfulandia/logistics/service/ShipmentServiceTest.java
+++ b/logistics/src/test/java/cl/perfulandia/logistics/service/ShipmentServiceTest.java
@@ -1,0 +1,13 @@
+package cl.perfulandia.logistics.service;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class ShipmentServiceTest {
+    @Test
+    void serviceInstantiates() {
+        ShipmentService service = new ShipmentService();
+        assertNotNull(service);
+    }
+}

--- a/suppliers/src/test/java/cl/perfulandia/suppliers/service/SupplierServiceTest.java
+++ b/suppliers/src/test/java/cl/perfulandia/suppliers/service/SupplierServiceTest.java
@@ -1,0 +1,34 @@
+package cl.perfulandia.suppliers.service;
+
+import cl.perfulandia.suppliers.model.Supplier;
+import cl.perfulandia.suppliers.repository.SupplierRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+class SupplierServiceTest {
+    @Mock
+    private SupplierRepository repo;
+    @InjectMocks
+    private ServiceProvider service;
+
+    @BeforeEach
+    void init() {
+        MockitoAnnotations.openMocks(this);
+    }
+
+    @Test
+    void createSupplierSaves() {
+        Supplier s = new Supplier();
+        when(repo.save(any())).thenReturn(s);
+        Supplier result = service.CreateSupplier(new Supplier());
+        assertNotNull(result);
+        verify(repo).save(any(Supplier.class));
+    }
+}


### PR DESCRIPTION
## Summary
- add ProductServiceTest covering CRUD operations in catalog module
- add placeholder tests for billing, logistics, and suppliers modules

## Testing
- `./mvnw -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_68674c7c297483269d6b46bbfbd75892