### PR TITLE
Fix supplier service names and cleanup

### DIFF
--- a/suppliers/src/main/java/cl/perfulandia/suppliers/model/OrderItem.java
+++ b/suppliers/src/main/java/cl/perfulandia/suppliers/model/OrderItem.java
@@ -8,8 +8,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @Entity
 @Table(name = "item_orden")
-
-public class ItemOrder {
+public class OrderItem {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/suppliers/src/main/java/cl/perfulandia/suppliers/model/Supplier.java
+++ b/suppliers/src/main/java/cl/perfulandia/suppliers/model/Supplier.java
@@ -1,4 +1,31 @@
 package cl.perfulandia.suppliers.model;
 
-public class Suplier {
+import jakarta.persistence.*;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@Entity
+@Table(name = "suppliers")
+public class Supplier {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, unique = true)
+    private String rut;
+
+    @Column(nullable = false)
+    private String nombre;
+
+    @Column(nullable = false)
+    private String direccion;
+
+    private String telefono;
+
+    @Column(nullable = false, unique = true)
+    private String email;
+
+    private String tipoProducto;
 }

--- a/suppliers/src/main/java/cl/perfulandia/suppliers/repository/ReplenishmentOrderRepository.java
+++ b/suppliers/src/main/java/cl/perfulandia/suppliers/repository/ReplenishmentOrderRepository.java
@@ -8,8 +8,7 @@ import java.util.List;
 import java.util.Optional;
 
 @Repository
-
-public interface OrderReplenishmentRepository extends JpaRepository<ReplenishmentOrder, Long>{
+public interface ReplenishmentOrderRepository extends JpaRepository<ReplenishmentOrder, Long> {
     List<ReplenishmentOrder> findByProveedorId(Long proveedorId);
     List<ReplenishmentOrder> findByEstado(ReplenishmentOrder.Estado estado);
     Optional<ReplenishmentOrder> findByCodigo(String codigo);

--- a/suppliers/src/main/java/cl/perfulandia/suppliers/repository/SupplierRepository.java
+++ b/suppliers/src/main/java/cl/perfulandia/suppliers/repository/SupplierRepository.java
@@ -7,7 +7,7 @@ import org.springframework.stereotype.Repository;
 import java.util.Optional;
 
 @Repository
-public interface ProviderRepository extends JpaRepository <Supplier, Long>{
+public interface SupplierRepository extends JpaRepository<Supplier, Long> {
     Optional<Supplier> findByRut(String rut);
     Optional<Supplier> findByEmail(String email);
     boolean existsByRut(String rut);

--- a/suppliers/src/main/java/cl/perfulandia/suppliers/service/ReplenishmentOrderService.java
+++ b/suppliers/src/main/java/cl/perfulandia/suppliers/service/ReplenishmentOrderService.java
@@ -1,7 +1,9 @@
 package cl.perfulandia.suppliers.service;
 
 
-import cl.perfulandia.suppliers.model.*;
+import cl.perfulandia.suppliers.model.OrderItem;
+import cl.perfulandia.suppliers.model.ReplenishmentOrder;
+import cl.perfulandia.suppliers.model.Supplier;
 import cl.perfulandia.suppliers.repository.ReplenishmentOrderRepository;
 import cl.perfulandia.suppliers.repository.SupplierRepository;
 import org.springframework.stereotype.Service;
@@ -10,22 +12,23 @@ import org.springframework.transaction.annotation.Transactional;
 import java.util.List;
 
 @Service
-public class OrderReplenishmentService {
+public class ReplenishmentOrderService {
 
     private final ReplenishmentOrderRepository replenishmentOrderRepository;
     private final SupplierRepository supplierRepository;
 
-    public OrderReplenishmentService (ReplenishmentOrderRepository replenishmentOrderRepository, SupplierRepository supplierRepository) {
+    public ReplenishmentOrderService(ReplenishmentOrderRepository replenishmentOrderRepository, SupplierRepository supplierRepository) {
         this.replenishmentOrderRepository = replenishmentOrderRepository;
         this.supplierRepository = supplierRepository;
     }
 
     @Transactional
-    public ReplenishmentOrder createOrder(long supplierId, List<ReplenishmentOrder> orders){
+    public ReplenishmentOrder createOrder(long supplierId, List<OrderItem> items){
         Supplier supplier = supplierRepository.findById(supplierId).orElseThrow(()->new RuntimeException("Supplier not found"));
 
         ReplenishmentOrder order = new ReplenishmentOrder();
-        order.setId(generarCodigoOrden);
+        // TODO: populate order fields when model is completed
+        return replenishmentOrderRepository.save(order);
     }
 
 

--- a/suppliers/src/main/java/cl/perfulandia/suppliers/service/SupplierService.java
+++ b/suppliers/src/main/java/cl/perfulandia/suppliers/service/SupplierService.java
@@ -9,16 +9,16 @@ import java.util.List;
 import java.util.Optional;
 
 @Service
-public class ServiceProvider {
+public class SupplierService {
 
     private final SupplierRepository supplierRepository;
 
-    public ServiceProvider(SupplierRepository supplierRepository) {
+    public SupplierService(SupplierRepository supplierRepository) {
         this.supplierRepository = supplierRepository;
     }
 
     @Transactional
-    public Supplier CreateSupplier(Supplier supplier){
+    public Supplier createSupplier(Supplier supplier) {
         if(supplierRepository.existsByRut(supplier.getRut())){
             throw new IllegalArgumentException("Provider already exists");
         }
@@ -29,7 +29,7 @@ public class ServiceProvider {
     }
 
     @Transactional(readOnly = true)
-    public List<Supplier> ListSupplier(){
+    public List<Supplier> listSuppliers() {
         return supplierRepository.findAll();
     }
 
@@ -39,32 +39,32 @@ public class ServiceProvider {
     }
 
     @Transactional( readOnly = true)
-    public Optional<Supplier> GetSupplierByRut (long id){
+    public Optional<Supplier> getSupplierById(long id) {
         return supplierRepository.findById(id);
     }
 
 
     @Transactional(readOnly = true)
-    public Supplier updateSupplier (Long id, Supplier supplierUpdate){
-        return SupplierRepository.findById(id).map(Supplier ->{
-            if(!Supplier.getRut().equals(supplierUpdate.getRut()) && SupplierRepository.existsByRut(supplierUpdate.getRut())){
+    public Supplier updateSupplier(Long id, Supplier supplierUpdate) {
+        return supplierRepository.findById(id).map(existing -> {
+            if (!existing.getRut().equals(supplierUpdate.getRut()) && supplierRepository.existsByRut(supplierUpdate.getRut())) {
                 throw new IllegalArgumentException("Provider already exists");
             }
-            if (!Supplier.getEmail().equals(supplierUpdate.getEmail()) && SupplierRepository.existsByEmail(supplierUpdate.getEmail())) {
+            if (!existing.getEmail().equals(supplierUpdate.getEmail()) && supplierRepository.existsByEmail(supplierUpdate.getEmail())) {
                 throw new IllegalArgumentException("Email already exists");
             }
-            Supplier.setNombre(supplierUpdate.getNombre());
-            Supplier.setDireccion(supplierUpdate.getDireccion());
-            Supplier.setTelefono(supplierUpdate.getTelefono());
-            Supplier.setEmail(supplierUpdate.getEmail());
-            Supplier.setTipoProducto(supplierUpdate.getTipoProducto());
-            return supplierRepository.save(Supplier);
-        }).orElseThrow(() -> new IllegalArgumentException("Supplier don't found by id:"+ id));
+            existing.setNombre(supplierUpdate.getNombre());
+            existing.setDireccion(supplierUpdate.getDireccion());
+            existing.setTelefono(supplierUpdate.getTelefono());
+            existing.setEmail(supplierUpdate.getEmail());
+            existing.setTipoProducto(supplierUpdate.getTipoProducto());
+            return supplierRepository.save(existing);
+        }).orElseThrow(() -> new IllegalArgumentException("Supplier don't found by id:" + id));
     }
 
     @Transactional
-    public void deleteSupplier (Long id){
-        SupplierRepository.deleteById(id);
+    public void deleteSupplier(Long id) {
+        supplierRepository.deleteById(id);
     }
 
 }

--- a/suppliers/src/test/java/cl/perfulandia/suppliers/service/SupplierServiceTest.java
+++ b/suppliers/src/test/java/cl/perfulandia/suppliers/service/SupplierServiceTest.java
@@ -16,7 +16,7 @@ class SupplierServiceTest {
     @Mock
     private SupplierRepository repo;
     @InjectMocks
-    private ServiceProvider service;
+    private SupplierService service;
 
     @BeforeEach
     void init() {
@@ -27,7 +27,7 @@ class SupplierServiceTest {
     void createSupplierSaves() {
         Supplier s = new Supplier();
         when(repo.save(any())).thenReturn(s);
-        Supplier result = service.CreateSupplier(new Supplier());
+        Supplier result = service.createSupplier(new Supplier());
         assertNotNull(result);
         verify(repo).save(any(Supplier.class));
     }

--- a/user/src/main/java/cl/perfulandia/user/service/UserService.java
+++ b/user/src/main/java/cl/perfulandia/user/service/UserService.java
@@ -36,7 +36,6 @@ public class UserService {
 
     @Transactional
     public UserResponse create(UserRequest req) {
-        System.out.println("RAW password recibida: " + req.getPassword());
 
         User u = User.builder()
                 .username(req.getUsername())


### PR DESCRIPTION
## Summary
- rename interfaces and classes in the `suppliers` module so their names match file names
- adjust service and test code for new names
- add a simple Supplier entity implementation
- update ReplenishmentOrder service stub
- remove debug output from `UserService`

## Testing
- `./mvnw -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_68674ed4f2e88326afbaf236ffdf7441