### PR TITLE
Fix JWT key usage

### DIFF
--- a/authentication/src/main/java/cl/perfulandia/authentication/util/JwtUtil.java
+++ b/authentication/src/main/java/cl/perfulandia/authentication/util/JwtUtil.java
@@ -1,10 +1,13 @@
 package cl.perfulandia.authentication.util;
 
 import io.jsonwebtoken.*;
+import io.jsonwebtoken.security.Keys;
+import javax.crypto.SecretKey;
 import jakarta.annotation.PostConstruct;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 import java.util.Date;
+import java.nio.charset.StandardCharsets;
 
 @Component
 public class JwtUtil {
@@ -16,10 +19,12 @@ public class JwtUtil {
     private long expirationMs;
 
     private JwtParser parser;
+    private SecretKey key;
 
     @PostConstruct
     public void init() {
-        this.parser = Jwts.parserBuilder().setSigningKey(secret.getBytes()).build();
+        this.key = Keys.hmacShaKeyFor(secret.getBytes(StandardCharsets.UTF_8));
+        this.parser = Jwts.parserBuilder().setSigningKey(key).build();
     }
 
     public String generateToken(String username, String role) {
@@ -28,7 +33,7 @@ public class JwtUtil {
                 .claim("role", role)
                 .setIssuedAt(new Date())
                 .setExpiration(new Date(System.currentTimeMillis() + expirationMs))
-                .signWith(SignatureAlgorithm.HS256, secret.getBytes())
+                .signWith(key, SignatureAlgorithm.HS256)
                 .compact();
     }
 

--- a/authentication/src/test/java/cl/perfulandia/authentication/util/JwtUtilTest.java
+++ b/authentication/src/test/java/cl/perfulandia/authentication/util/JwtUtilTest.java
@@ -14,7 +14,7 @@ class JwtUtilTest {
     @BeforeEach
     void setUp() {
         util = new JwtUtil();
-        ReflectionTestUtils.setField(util, "secret", "secretkey");
+        ReflectionTestUtils.setField(util, "secret", "UnaClaveMuyLargaDe32Caracteres..");
         ReflectionTestUtils.setField(util, "expirationMs", 3600000L);
         util.init();
     }

--- a/branches/src/main/java/cl/perfulandia/branches/util/JwtUtil.java
+++ b/branches/src/main/java/cl/perfulandia/branches/util/JwtUtil.java
@@ -1,10 +1,13 @@
 package cl.perfulandia.branches.util;
 
 import io.jsonwebtoken.*;
+import io.jsonwebtoken.security.Keys;
+import javax.crypto.SecretKey;
 import jakarta.annotation.PostConstruct;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 import java.util.Date;
+import java.nio.charset.StandardCharsets;
 
 @Component
 public class JwtUtil {
@@ -16,10 +19,12 @@ public class JwtUtil {
     private long expirationMs;
 
     private JwtParser parser;
+    private SecretKey key;
 
     @PostConstruct
     public void init() {
-        this.parser = Jwts.parserBuilder().setSigningKey(secret.getBytes()).build();
+        this.key = Keys.hmacShaKeyFor(secret.getBytes(StandardCharsets.UTF_8));
+        this.parser = Jwts.parserBuilder().setSigningKey(key).build();
     }
 
     public String generateToken(String username, String role) {
@@ -28,7 +33,7 @@ public class JwtUtil {
                 .claim("role", role)
                 .setIssuedAt(new Date())
                 .setExpiration(new Date(System.currentTimeMillis() + expirationMs))
-                .signWith(SignatureAlgorithm.HS256, secret.getBytes())
+                .signWith(key, SignatureAlgorithm.HS256)
                 .compact();
     }
 

--- a/catalog/src/main/java/cl/perfulandia/catalog/util/JwtUtil.java
+++ b/catalog/src/main/java/cl/perfulandia/catalog/util/JwtUtil.java
@@ -1,10 +1,13 @@
 package cl.perfulandia.catalog.util;
 
 import io.jsonwebtoken.*;
+import io.jsonwebtoken.security.Keys;
+import javax.crypto.SecretKey;
 import jakarta.annotation.PostConstruct;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 import java.util.Date;
+import java.nio.charset.StandardCharsets;
 
 @Component
 public class JwtUtil {
@@ -16,10 +19,12 @@ public class JwtUtil {
     private long expirationMs;
 
     private JwtParser parser;
+    private SecretKey key;
 
     @PostConstruct
     public void init() {
-        this.parser = Jwts.parserBuilder().setSigningKey(secret.getBytes()).build();
+        this.key = Keys.hmacShaKeyFor(secret.getBytes(StandardCharsets.UTF_8));
+        this.parser = Jwts.parserBuilder().setSigningKey(key).build();
     }
 
     public String generateToken(String username, String role) {
@@ -28,7 +33,7 @@ public class JwtUtil {
                 .claim("role", role)
                 .setIssuedAt(new Date())
                 .setExpiration(new Date(System.currentTimeMillis() + expirationMs))
-                .signWith(SignatureAlgorithm.HS256, secret.getBytes())
+                .signWith(key, SignatureAlgorithm.HS256)
                 .compact();
     }
 

--- a/sale/src/main/java/cl/perfulandia/sale/util/JwtUtil.java
+++ b/sale/src/main/java/cl/perfulandia/sale/util/JwtUtil.java
@@ -1,10 +1,13 @@
 package cl.perfulandia.sale.util;
 
 import io.jsonwebtoken.*;
+import io.jsonwebtoken.security.Keys;
+import javax.crypto.SecretKey;
 import jakarta.annotation.PostConstruct;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 import java.util.Date;
+import java.nio.charset.StandardCharsets;
 
 @Component
 public class JwtUtil {
@@ -16,10 +19,12 @@ public class JwtUtil {
     private long expirationMs;
 
     private JwtParser parser;
+    private SecretKey key;
 
     @PostConstruct
     public void init() {
-        this.parser = Jwts.parserBuilder().setSigningKey(secret.getBytes()).build();
+        this.key = Keys.hmacShaKeyFor(secret.getBytes(StandardCharsets.UTF_8));
+        this.parser = Jwts.parserBuilder().setSigningKey(key).build();
     }
 
     public String generateToken(String username, String role) {
@@ -28,7 +33,7 @@ public class JwtUtil {
                 .claim("role", role)
                 .setIssuedAt(new Date())
                 .setExpiration(new Date(System.currentTimeMillis() + expirationMs))
-                .signWith(SignatureAlgorithm.HS256, secret.getBytes())
+                .signWith(key, SignatureAlgorithm.HS256)
                 .compact();
     }
 

--- a/user/src/main/java/cl/perfulandia/user/util/JwtUtil.java
+++ b/user/src/main/java/cl/perfulandia/user/util/JwtUtil.java
@@ -1,10 +1,13 @@
 package cl.perfulandia.user.util;
 
 import io.jsonwebtoken.*;
+import io.jsonwebtoken.security.Keys;
+import javax.crypto.SecretKey;
 import jakarta.annotation.PostConstruct;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 import java.util.Date;
+import java.nio.charset.StandardCharsets;
 
 @Component
 public class JwtUtil {
@@ -16,10 +19,12 @@ public class JwtUtil {
     private long expirationMs;
 
     private JwtParser parser;
+    private SecretKey key;
 
     @PostConstruct
     public void init() {
-        this.parser = Jwts.parserBuilder().setSigningKey(secret.getBytes()).build();
+        this.key = Keys.hmacShaKeyFor(secret.getBytes(StandardCharsets.UTF_8));
+        this.parser = Jwts.parserBuilder().setSigningKey(key).build();
     }
 
     public String generateToken(String username, String role) {
@@ -28,7 +33,7 @@ public class JwtUtil {
                 .claim("role", role)
                 .setIssuedAt(new Date())
                 .setExpiration(new Date(System.currentTimeMillis() + expirationMs))
-                .signWith(SignatureAlgorithm.HS256, secret.getBytes())
+                .signWith(key, SignatureAlgorithm.HS256)
                 .compact();
     }
 


### PR DESCRIPTION
## Summary
- fix insecure `JwtUtil` key generation by using `Keys.hmacShaKeyFor`
- adjust `JwtUtilTest` to use a 256‑bit key
- update all modules using the same utility

## Testing
- `./mvnw -q test` *(fails: Could not resolve dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_686750a5e65c8326ab900942f4eab280