### PR TITLE
Fix Invoice class name

### DIFF
--- a/billing/src/main/java/cl/perfulandia/billing/model/Invoice.java
+++ b/billing/src/main/java/cl/perfulandia/billing/model/Invoice.java
@@ -1,6 +1,4 @@
 package cl.perfulandia.billing.model;
 
-
-
-public class Model {
+public class Invoice {
 }


### PR DESCRIPTION
## Summary
- rename `Model` class in billing module to `Invoice`

## Testing
- `mvnw test` *(fails: cannot resolve parent POM due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_686753d332748326abb3d0eacb704871