### PR TITLE
Fix billing tests by disabling DataSource auto-config

### DIFF
--- a/billing/src/test/resources/application.properties
+++ b/billing/src/test/resources/application.properties
@@ -1,0 +1,1 @@
+spring.autoconfigure.exclude=org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration,org.springframework.boot.autoconfigure.orm.jpa.HibernateJpaAutoConfiguration


### PR DESCRIPTION
## Summary
- provide a test `application.properties` in `billing` module to avoid DataSource configuration during tests

## Testing
- `mvn -pl billing test` *(fails: Non-resolvable parent POM due to network issues)*

------
https://chatgpt.com/codex/tasks/task_e_6867552798588326bc83a38f7ea2bcd1