### PR TITLE
Add logistics datasource properties

### DIFF
--- a/logistics/src/main/resources/application.properties
+++ b/logistics/src/main/resources/application.properties
@@ -1,0 +1,14 @@
+spring.application.name=logistics
+
+server.port=8085
+
+spring.datasource.url=jdbc:postgresql://localhost:5432/logisticsdb
+spring.datasource.username=modonor
+spring.datasource.password=modonor
+
+spring.jpa.hibernate.ddl-auto=update
+spring.jpa.show-sql=true
+
+jwt.secret=UnaClaveMuyLargaDe32Caracteres..
+jwt.expiration-ms=3600000
+jwt.cookie-name=token


### PR DESCRIPTION
## Summary
- configure datasource for the `logistics` module

## Testing
- `mvnw -pl logistics test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_6867566724008326a2b402fc0791b706