### PR TITLE
Fix logistics tests without DB

### DIFF
--- a/logistics/pom.xml
+++ b/logistics/pom.xml
@@ -12,4 +12,11 @@
     <version>0.0.1-SNAPSHOT</version>
     <name>logistics</name>
     <description>logistics</description>
+    <dependencies>
+        <dependency>
+            <groupId>com.h2database</groupId>
+            <artifactId>h2</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
 </project>

--- a/logistics/src/test/resources/application.properties
+++ b/logistics/src/test/resources/application.properties
@@ -1,0 +1,6 @@
+spring.datasource.url=jdbc:h2:mem:testdb
+spring.datasource.driverClassName=org.h2.Driver
+spring.datasource.username=sa
+spring.datasource.password=
+spring.jpa.database-platform=org.hibernate.dialect.H2Dialect
+spring.jpa.hibernate.ddl-auto=create-drop


### PR DESCRIPTION
## Summary
- add H2 database for logistics tests
- configure in-memory datasource for logistic tests

## Testing
- `./mvnw -q -pl logistics test` *(fails: Non-resolvable parent POM due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_6867579c787883269a1240ed369dfa7e