### PR TITLE
Add database driver presence tests

### DIFF
--- a/suppliers/src/test/java/cl/perfulandia/suppliers/config/DriverCheckTests.java
+++ b/suppliers/src/test/java/cl/perfulandia/suppliers/config/DriverCheckTests.java
@@ -1,0 +1,19 @@
+package cl.perfulandia.suppliers.config;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class DriverCheckTests {
+
+    @Test
+    void databaseDriverIsPresent() {
+        assertDoesNotThrow(() -> Class.forName("org.postgresql.Driver"));
+    }
+
+    @Test
+    void missingDriverCausesException() {
+        assertThrows(ClassNotFoundException.class,
+                () -> Class.forName("non.existent.Driver"));
+    }
+}


### PR DESCRIPTION
## Summary
- add driver presence tests for suppliers

## Testing
- `mvn -o -pl suppliers test` *(fails: Non-resolvable parent POM due to lack of network access)*

------
https://chatgpt.com/codex/tasks/task_e_68675ab8bb788326acb4ebc6254f7f44