### PR TITLE
Fix suppliers tests without DB

### DIFF
--- a/suppliers/src/test/resources/application.properties
+++ b/suppliers/src/test/resources/application.properties
@@ -1,0 +1,1 @@
+spring.autoconfigure.exclude=org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration,org.springframework.boot.autoconfigure.orm.jpa.HibernateJpaAutoConfiguration


### PR DESCRIPTION
## Summary
- add test properties to skip DB setup for suppliers module

## Testing
- `./mvnw -q test` *(fails: Non-resolvable parent POM due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_68675bfd7e688326878b930e2a849ea4