### PR TITLE
Fix supplier tests JPA config

### DIFF
--- a/suppliers/pom.xml
+++ b/suppliers/pom.xml
@@ -7,9 +7,16 @@
         <artifactId>perfulandia</artifactId>
         <version>0.0.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
-    </parent>
-    <artifactId>suppliers</artifactId>
-    <version>0.0.1-SNAPSHOT</version>
-    <name>suppliers</name>
-    <description>suppliers</description>
+</parent>
+<artifactId>suppliers</artifactId>
+<version>0.0.1-SNAPSHOT</version>
+<name>suppliers</name>
+<description>suppliers</description>
+<dependencies>
+    <dependency>
+        <groupId>com.h2database</groupId>
+        <artifactId>h2</artifactId>
+        <scope>test</scope>
+    </dependency>
+</dependencies>
 </project>

--- a/suppliers/src/test/resources/application.properties
+++ b/suppliers/src/test/resources/application.properties
@@ -1,1 +1,6 @@
-spring.autoconfigure.exclude=org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration,org.springframework.boot.autoconfigure.orm.jpa.HibernateJpaAutoConfiguration
+spring.datasource.url=jdbc:h2:mem:testdb
+spring.datasource.driverClassName=org.h2.Driver
+spring.datasource.username=sa
+spring.datasource.password=
+spring.jpa.database-platform=org.hibernate.dialect.H2Dialect
+spring.jpa.hibernate.ddl-auto=create-drop


### PR DESCRIPTION
## Summary
- add H2 test dependency for supplier module
- configure supplier tests to use H2 and enable JPA

## Testing
- `./mvnw -q -o test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_68675d381d3483269a70276dbd009707