### PR TITLE
Improve service tests

### DIFF
--- a/billing/src/test/java/cl/perfulandia/billing/service/InvoiceServiceTest.java
+++ b/billing/src/test/java/cl/perfulandia/billing/service/InvoiceServiceTest.java
@@ -1,13 +1,74 @@
 package cl.perfulandia.billing.service;
 
+import cl.perfulandia.billing.model.Invoice;
+import cl.perfulandia.billing.repository.InvoiceRepository;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import java.util.Collections;
+import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
 
 class InvoiceServiceTest {
+
+    @Mock
+    private InvoiceRepository repository;
+    @InjectMocks
+    private InvoiceService service;
+
+    @BeforeEach
+    void setup() {
+        MockitoAnnotations.openMocks(this);
+    }
+
     @Test
-    void serviceInstantiates() {
-        InvoiceService service = new InvoiceService();
-        assertNotNull(service);
+    void createInvoiceSavesAndInitializes() {
+        Invoice invoice = new Invoice();
+        when(repository.save(any())).thenAnswer(i -> i.getArgument(0));
+
+        Invoice result = service.createInvoice(invoice);
+
+        assertNotNull(result.getDateIssued());
+        assertFalse(result.getPaid());
+        verify(repository).save(invoice);
+    }
+
+    @Test
+    void markAsPaidUpdatesInvoice() {
+        Invoice invoice = new Invoice();
+        invoice.setPaid(false);
+        when(repository.findById(1L)).thenReturn(Optional.of(invoice));
+        when(repository.save(any())).thenAnswer(i -> i.getArgument(0));
+
+        Invoice result = service.markAsPaid(1L);
+
+        assertTrue(result.getPaid());
+        verify(repository).findById(1L);
+        verify(repository).save(invoice);
+    }
+
+    @Test
+    void getAllInvoicesDelegatesToRepository() {
+        when(repository.findAll()).thenReturn(Collections.emptyList());
+
+        assertEquals(0, service.getAllInvoices().size());
+        verify(repository).findAll();
+    }
+
+    @Test
+    void getInvoiceByIdReturnsValue() {
+        Invoice invoice = new Invoice();
+        when(repository.findById(2L)).thenReturn(Optional.of(invoice));
+
+        Invoice result = service.getInvoiceById(2L);
+
+        assertSame(invoice, result);
+        verify(repository).findById(2L);
     }
 }

--- a/logistics/src/test/java/cl/perfulandia/logistics/service/ShipmentServiceTest.java
+++ b/logistics/src/test/java/cl/perfulandia/logistics/service/ShipmentServiceTest.java
@@ -1,13 +1,54 @@
 package cl.perfulandia.logistics.service;
 
+import cl.perfulandia.logistics.model.Shipment;
+import cl.perfulandia.logistics.repository.ShipmentRepository;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
 
 class ShipmentServiceTest {
+
+    @Mock
+    private ShipmentRepository repository;
+    @InjectMocks
+    private ShipmentService service;
+
+    @BeforeEach
+    void setup() {
+        MockitoAnnotations.openMocks(this);
+    }
+
     @Test
-    void serviceInstantiates() {
-        ShipmentService service = new ShipmentService();
-        assertNotNull(service);
+    void createShipmentInitializesAndSaves() {
+        Shipment shipment = new Shipment();
+        when(repository.save(any())).thenAnswer(i -> i.getArgument(0));
+
+        Shipment result = service.createShipment(shipment);
+
+        assertNotNull(result.getCreatedAt());
+        assertEquals("Preparando", result.getCurrentStatus());
+        verify(repository).save(shipment);
+    }
+
+    @Test
+    void updateStatusUpdatesAndPersists() {
+        Shipment shipment = new Shipment();
+        shipment.setId(1L);
+        when(repository.findById(1L)).thenReturn(Optional.of(shipment));
+        when(repository.save(any())).thenAnswer(i -> i.getArgument(0));
+
+        Shipment result = service.updateStatus(1L, "Enviado");
+
+        assertEquals("Enviado", result.getCurrentStatus());
+        verify(repository).findById(1L);
+        verify(repository).save(shipment);
     }
 }

--- a/suppliers/src/test/java/cl/perfulandia/suppliers/service/SupplierServiceTest.java
+++ b/suppliers/src/test/java/cl/perfulandia/suppliers/service/SupplierServiceTest.java
@@ -8,6 +8,8 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
+import java.util.Optional;
+
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
@@ -30,5 +32,33 @@ class SupplierServiceTest {
         Supplier result = service.createSupplier(new Supplier());
         assertNotNull(result);
         verify(repo).save(any(Supplier.class));
+    }
+
+    @Test
+    void createSupplierFailsWhenEmailExists() {
+        Supplier s = new Supplier();
+        s.setEmail("existing@test.com");
+
+        when(repo.existsByTaxId(any())).thenReturn(false);
+        when(repo.existsByEmail("existing@test.com")).thenReturn(true);
+
+        assertThrows(IllegalArgumentException.class, () -> service.createSupplier(s));
+    }
+
+    @Test
+    void updateSupplierThrowsWhenTaxIdExists() {
+        Supplier existing = new Supplier();
+        existing.setId(1L);
+        existing.setTaxId("1");
+        existing.setEmail("orig@test.com");
+
+        Supplier update = new Supplier();
+        update.setTaxId("2");
+        update.setEmail("orig@test.com");
+
+        when(repo.findById(1L)).thenReturn(Optional.of(existing));
+        when(repo.existsByTaxId("2")).thenReturn(true);
+
+        assertThrows(IllegalArgumentException.class, () -> service.updateSupplier(1L, update));
     }
 }


### PR DESCRIPTION
## Summary
- update service tests for billing module using Mockito
- update service tests for logistics module using Mockito
- expand supplier service tests with more scenarios

## Testing
- `./mvnw -q -DskipTests=false test` *(fails: Non-resolvable parent POM due to network)*

------
https://chatgpt.com/codex/tasks/task_e_6867e9212fa88326bd5a4f8398a7b469