### PR TITLE
Fix billing module tests

### DIFF
--- a/billing/pom.xml
+++ b/billing/pom.xml
@@ -12,4 +12,11 @@
     <version>0.0.1-SNAPSHOT</version>
     <name>billing</name>
     <description>billing</description>
+    <dependencies>
+        <dependency>
+            <groupId>com.h2database</groupId>
+            <artifactId>h2</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
 </project>


### PR DESCRIPTION
## Summary
- add H2 dependency to the billing module so tests can use the in-memory database

## Testing
- `./mvnw -o -q test` *(fails: cannot resolve Spring Boot parent)*

------
https://chatgpt.com/codex/tasks/task_e_6867ef2ad66c8326b0467c48cd21f856