### PR TITLE
Fix Billing tests by mocking email sender

### DIFF
--- a/billing/src/test/java/cl/perfulandia/billing/BillingApplicationTests.java
+++ b/billing/src/test/java/cl/perfulandia/billing/BillingApplicationTests.java
@@ -2,9 +2,13 @@ package cl.perfulandia.billing;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.mail.javamail.JavaMailSender;
 
 @SpringBootTest
 class BillingApplicationTests {
+    @MockBean
+    private JavaMailSender mailSender;
     @Test
     void contextLoads() {
     }


### PR DESCRIPTION
## Summary
- mock JavaMailSender in BillingApplicationTests so context loads

## Testing
- `./mvnw -q -pl billing test -o` *(fails: unresolved parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_6867f12343d48326bceb7274cc6aba7f