### PR TITLE
Fix tests by adding JWT properties

### DIFF
--- a/billing/src/test/resources/application.properties
+++ b/billing/src/test/resources/application.properties
@@ -4,3 +4,8 @@ spring.datasource.username=sa
 spring.datasource.password=
 spring.jpa.database-platform=org.hibernate.dialect.H2Dialect
 spring.jpa.hibernate.ddl-auto=create-drop
+
+# JWT configuration for tests
+jwt.secret=TestSecretKey1234567890123456789012345
+jwt.expiration-ms=3600000
+


### PR DESCRIPTION
## Summary
- ensure billing tests have JWT configuration

## Testing
- `mvn -q -pl billing test` *(fails: Could not resolve parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_6868672e1f70832696ca6c2a8e406eb3