### PR TITLE
Fix null items in replenishment order requests

### DIFF
--- a/suppliers/src/main/java/cl/perfulandia/suppliers/controller/ReplenishmentOrderController.java
+++ b/suppliers/src/main/java/cl/perfulandia/suppliers/controller/ReplenishmentOrderController.java
@@ -24,6 +24,11 @@ public class ReplenishmentOrderController {
     public ResponseEntity<ReplenishmentOrderResponse> createOrder(
             @RequestBody ReplenishmentOrderRequest request) {
 
+        if (request == null || request.getSupplierId() == null ||
+                request.getItems() == null || request.getItems().isEmpty()) {
+            return ResponseEntity.badRequest().build();
+        }
+
         Long supplierId = request.getSupplierId();
         List<OrderItemRequest> itemsRequest = request.getItems();
 


### PR DESCRIPTION
## Summary
- validate the items list in `ReplenishmentOrderController`

## Testing
- `./mvnw -q -pl suppliers test` *(fails: could not resolve spring-boot-starter-parent due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_686880f9eb4c8326b73af8d841eea6aa